### PR TITLE
fix: typo breaking build

### DIFF
--- a/velocity/src/main/java/eu/kennytv/maintenance/addon/velocity/listener/MessagingListener.java
+++ b/velocity/src/main/java/eu/kennytv/maintenance/addon/velocity/listener/MessagingListener.java
@@ -17,7 +17,7 @@ public final class MessagingListener {
     public void execute(final PluginMessageEvent event) {
         if (!event.getIdentifier().getId().equals(MaintenanceChannel.REQUEST_CHANNEL_ID)) return;
         event.setResult(PluginMessageEvent.ForwardResult.handled());
-        if (event.getSourcce() instanceof Player) return;
+        if (event.getSource() instanceof Player) return;
         plugin.messageSender().sendMessages();
         plugin.messageSender().sendAllServers();
     }


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/kennytv/MaintenanceAddon/commit/628fc1dbee13946684c615b7c0387c0b3005fd80 that broke build