### PR TITLE
[Feature] Add support for MiniPlaceholders v3

### DIFF
--- a/build-logic/src/main/kotlin/maintenanceaddon.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/maintenanceaddon.base-conventions.gradle.kts
@@ -18,4 +18,4 @@ tasks {
     }
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,10 +5,10 @@ adventure = "4.17.0"
 # Provided
 maintenance = "4.2.1"
 
-miniplaceholders = "2.2.3"
+miniplaceholders = "3.1.0"
 placeholderapi = "2.11.6"
 
-bungee = "1.20-R0.1-SNAPSHOT"
+bungee = "1.21-R0.4-SNAPSHOT"
 paper = "1.20.4-R0.1-SNAPSHOT"
 velocity = "3.3.0-SNAPSHOT"
 

--- a/paper/src/main/java/eu/kennytv/maintenance/addon/paper/expansion/MaintenanceMiniPlaceholdersExpansion.java
+++ b/paper/src/main/java/eu/kennytv/maintenance/addon/paper/expansion/MaintenanceMiniPlaceholdersExpansion.java
@@ -2,8 +2,9 @@ package eu.kennytv.maintenance.addon.paper.expansion;
 
 import eu.kennytv.maintenance.addon.paper.MaintenancePaperAddon;
 import io.github.miniplaceholders.api.Expansion;
-import io.github.miniplaceholders.api.utils.TagsUtils;
+import io.github.miniplaceholders.api.utils.Tags;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.Tag;
 
 public final class MaintenanceMiniPlaceholdersExpansion {
 	private final MiniMessage miniMessage = MiniMessage.miniMessage();
@@ -11,6 +12,8 @@ public final class MaintenanceMiniPlaceholdersExpansion {
 
 	public MaintenanceMiniPlaceholdersExpansion(MaintenancePaperAddon plugin) {
 		expansion = Expansion.builder("maintenance")
+				.author("kennytv")
+				.version("3.0.0-SNAPSHOT")
 				.globalPlaceholder("status", (queue, ctx) -> {
 					String status;
 					if (!queue.hasNext()) {
@@ -22,10 +25,10 @@ public final class MaintenanceMiniPlaceholdersExpansion {
 					}
 
 					if (status == null) {
-						return TagsUtils.EMPTY_TAG;
+						return Tags.EMPTY_TAG;
 					}
 
-					return TagsUtils.staticTag(miniMessage.deserialize(status));
+					return Tag.selfClosingInserting(miniMessage.deserialize(status));
 				}).build();
 	}
 

--- a/velocity/src/main/java/eu/kennytv/maintenance/addon/velocity/expansion/MaintenanceMiniPlaceholdersExpansion.java
+++ b/velocity/src/main/java/eu/kennytv/maintenance/addon/velocity/expansion/MaintenanceMiniPlaceholdersExpansion.java
@@ -3,8 +3,9 @@ package eu.kennytv.maintenance.addon.velocity.expansion;
 import eu.kennytv.maintenance.api.proxy.MaintenanceProxy;
 import eu.kennytv.maintenance.core.config.Config;
 import io.github.miniplaceholders.api.Expansion;
-import io.github.miniplaceholders.api.utils.TagsUtils;
+import io.github.miniplaceholders.api.utils.Tags;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.Tag;
 
 public final class MaintenanceMiniPlaceholdersExpansion {
 	private final MiniMessage miniMessage = MiniMessage.miniMessage();
@@ -22,10 +23,10 @@ public final class MaintenanceMiniPlaceholdersExpansion {
 					}
 
 					if (status == null) {
-						return TagsUtils.EMPTY_TAG;
+						return Tags.EMPTY_TAG;
 					}
 
-					return TagsUtils.staticTag(miniMessage.deserialize(status));
+					return Tag.selfClosingInserting(miniMessage.deserialize(status));
 				}).build();
 	}
 


### PR DESCRIPTION
Please note that this breaks the compatibility with MiniPlaceholders v2 as v3 is not backwards compatible.

I also had to bump Java version to 21 which is now required by MiniPlaceholders.

Bumped Bungeecord API due to the old API version not being in any of the maven repositories anymore, preventing building the project.